### PR TITLE
[Benchmark] Ratio Benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@
 build
 data
 third_party
+
+# Benchmark Results
+benchmark/read_order_percentile/*.json
+benchmark/read_order_percentile/*.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,6 @@ RUN pip install pyarrow
 
 ### duckdb
 RUN pip install duckdb
+
+### benchmark related libs. 
+RUN pip install matplotlib

--- a/benchmark/read_order_percentile/README.md
+++ b/benchmark/read_order_percentile/README.md
@@ -42,7 +42,7 @@ An in-memory connection is utilized for DuckDB to preclude I/O overhead, and the
 
 ## Prepared Query
 
-Sorting tests are conducted based on number, string, and mixed criteria. Sorting keys vary from 1 to 4 to assess the impact of additional sorting keys. The selection of attributes for sorting, especially for multiple key scenarios (e.g., `ORDER BY A, B`), is designed to ensure meaningful sorting by choosing attributes with many repeated values for A to necessitate sorting on B.
+Sorting tests are conducted based on number, string, and mixed criteria. Sorting keys vary from 1 to 4 to assess the impact of additional sorting keys. The selection of attributes for sorting, especially for multiple key scenarios (e.g., `ORDER BY A, B`), is designed to ensure meaningful sorting by choosing attributes with many repeated values for A to necessitate sorting on B. Attributes are selected based on the description found in [TPCH Standard Specification](https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v2.17.1.pdf).
 
 # Current Result (warmup = 2,iteration = 100, scale = 1)
 

--- a/benchmark/read_order_percentile/README.md
+++ b/benchmark/read_order_percentile/README.md
@@ -1,0 +1,49 @@
+# Benchmark Goal
+The objective is to compare the time costs between Arrow's parquet file reading operation and DuckDB's sorting operation.
+
+# Dataset
+The benchmark focuses on a single table, lineitem.parquet, chosen for its substantial number of rows and attributes, which aligns closely with OLAP workloads. This approach simplifies the comparison by avoiding the complexities of join operations. However, merging multiple tables into a larger dataset could be considered for future tests.
+
+# Test Design
+
+**Configuration**  
+
+The benchmark includes several warm-up rounds to mitigate the impact of cold starts. Tests are repeated a specified number of times (controlled by a configurable variable), and results are determined by calculating the average time taken. This method was validated through preliminary experiments, showing the average time typically falls around the 50th percentile. Median times are also recorded and available for reference.
+
+**Configurable Parameters**
+
+| Parameter | Description | Default Value |
+| --------- | ----------- | -------------- |
+| -s,--scale| TPCH scale  |  1        |
+| -w,--wamup | Number of warmup rounds| 2|
+| -i,--iterations| Number of iterations per test| 20 |
+| -f,--output | Output file name for benchmark | duckdb_bench_res_{scale}.json|
+
+## Arrow Read
+
+Following code is used for parquet reading time measurement.
+
+```
+def arrow_read(file_name):
+    parquet_table = pq.read_table(file_name)
+    return parquet_table
+```
+
+## DuckDB Sort
+
+Following code is used for duckdb sorting measurement:
+
+```
+def duckdb_sort(sort_query, conn):
+    res = conn.execute(sort_query)
+    return res
+```
+An in-memory connection is utilized for DuckDB to preclude I/O overhead, and the table is preloaded accordingly. Input queries are prepared in advance.
+
+## Prepared Query
+
+Sorting tests are conducted based on number, string, and mixed criteria. Sorting keys vary from 1 to 4 to assess the impact of additional sorting keys. The selection of attributes for sorting, especially for multiple key scenarios (e.g., `ORDER BY A, B`), is designed to ensure meaningful sorting by choosing attributes with many repeated values for A to necessitate sorting on B.
+
+# Current Result (warmup = 2,iteration = 100, scale = 1)
+
+The benchmark, with parameters set to `warmup = 2`, `iteration = 100`, and `scale = 1`, demonstrates that parquet reading consumes a significant portion of time compared to DuckDB sorting. Although this ratio decreases as the number of sorting keys increases, the minimum observed ratio of Read/Sort time is still substantial at 11%, with most scenarios showing a ratio above 30%. Partial tests conducted on a `scale = 2` dataset yielded comparable results. An additional experiment, measuring the time DuckDB takes to import a parquet file using `CREATE TABLE test AS SELECT * FROM 'filename'`, showed times closely aligned with Arrow's reading performance.

--- a/benchmark/read_order_percentile/README.md
+++ b/benchmark/read_order_percentile/README.md
@@ -15,7 +15,7 @@ The benchmark includes several warm-up rounds to mitigate the impact of cold sta
 | Parameter | Description | Default Value |
 | --------- | ----------- | -------------- |
 | -s,--scale| TPCH scale  |  1        |
-| -w,--wamup | Number of warmup rounds| 2|
+| -w,--wamrup | Number of warmup rounds| 2|
 | -i,--iterations| Number of iterations per test| 20 |
 | -f,--output | Output file name for benchmark | duckdb_bench_res_{scale}.json|
 

--- a/benchmark/read_order_percentile/with_duckdb.py
+++ b/benchmark/read_order_percentile/with_duckdb.py
@@ -88,7 +88,7 @@ def benchmark(discription, attr_num, benchmark_func, warmup, iterations, *args):
     std_time = np.std(times)
 
     # Calculate the percentiles for the average
-    avg_percentile = _calculate_percentile(times, median_time)
+    avg_percentile = _calculate_percentile(times, avg_time)
 
     print(f"Benchmark {discription} finished. Avg time: {avg_time} ms.")
     # Return a dictionary

--- a/benchmark/read_order_percentile/with_duckdb.py
+++ b/benchmark/read_order_percentile/with_duckdb.py
@@ -188,7 +188,7 @@ def string_bench(warmup, itr, con):
     query_one_item_fixed = "SELECT * FROM lineitem ORDER BY L_SHIPMODE"
     query_two_item = "SELECT * FROM lineitem ORDER BY L_SHIPMODE, L_SHIPINSTRUCT"
     query_three_item = (
-        "SELECT * FROM lineitem ORDER BY L_SHIPMODE, L_SHIPINSTRUCT, L_RETURNFLAG"
+        "SELECT * FROM lineitem ORDER BY L_SHIPMODE DESC, L_SHIPINSTRUCT, L_RETURNFLAG"
     )
     query_four_item = "SELECT * FROM lineitem ORDER BY L_SHIPMODE, L_SHIPINSTRUCT, L_RETURNFLAG, L_COMMENT"
     res1 = benchmark(

--- a/benchmark/read_order_percentile/with_duckdb.py
+++ b/benchmark/read_order_percentile/with_duckdb.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+import json
+import os
+import time
+from argparse import ArgumentParser
+
+import duckdb
+import matplotlib.pyplot as plt
+import numpy as np
+import pyarrow.parquet as pq
+
+workdir = "/workspace/whippet_docker"
+
+
+def parse_args():
+    parser = ArgumentParser(
+        description="Calculate the proportion of the time required \
+                     to read a Parquet file to the time required for sorting"
+    )
+    parser.add_argument("-s", "--scale", type=int, choices=range(1, 8), default=1)
+    parser.add_argument("-w", "--warmup", type=int, default=2)
+    parser.add_argument("-i", "--iterations", type=int, default=20)
+    parser.add_argument("-f", "--output", type=str, default=None)
+    args = parser.parse_args()
+    # Set default output filename if not specified
+    if args.output is None:
+        args.output = f"duckdb_bench_res_{args.scale}.json"
+    return args
+
+
+# Append the percentage of the average time to the result dictionary
+def add_percentage(read_avg, sort_res):
+    for res in sort_res:
+        res["Read/Sort Ratio"] = read_avg / res["avg"]
+    return
+
+
+# Calculate the percentile of the value in the array
+def _calculate_percentile(arr, value):
+    arr.sort()
+    index = np.searchsorted(arr, value)
+    percentile = index / len(arr)
+    return percentile
+
+
+# Benchmark code for arrow read
+def arrow_read(file_name):
+    parquet_table = pq.read_table(file_name)
+    return parquet_table
+
+
+# Prepare for duckdb table, eliminate the IO overhead
+def duckdb_preapre(scale, table_src_name):
+    # Check existence of the table
+    file_path = f"{workdir}/data/tpch/s{scale}/{table_src_name}"
+    if not os.path.exists(file_path):
+        print(f"File {file_path} does not exist.")
+        exit(-1)
+    con = duckdb.connect()
+    query = f"CREATE TABLE lineitem AS SELECT * FROM read_parquet('{file_path}')"
+    con.execute(query)
+    return con
+
+
+# Benchmark code for duckdb sort
+def duckdb_sort(sort_query, conn):
+    res = conn.execute(sort_query)
+    return res
+
+
+def benchmark(discription, attr_num, benchmark_func, warmup, iterations, *args):
+    # Warmup phase
+    for i in range(warmup):
+        benchmark_func(*args)
+
+    times = []
+    for i in range(iterations):
+        start = time.perf_counter() * 1000
+        res = benchmark_func(*args)
+        end = time.perf_counter() * 1000
+        times.append(end - start)
+
+    times = np.array(times)
+    min_time = np.min(times)
+    max_time = np.max(times)
+    avg_time = np.mean(times)
+    median_time = np.median(times)
+    std_time = np.std(times)
+
+    # Calculate the percentiles for the average
+    avg_percentile = _calculate_percentile(times, median_time)
+
+    print(f"Benchmark {discription} finished. Avg time: {avg_time} ms.")
+    # Return a dictionary
+    return {
+        "Description": discription,
+        "Number of Attributes": attr_num,
+        "min": min_time,
+        "max": max_time,
+        "avg": avg_time,
+        "median": median_time,
+        "std": std_time,
+        "avg_percentile": avg_percentile,
+    }
+
+
+def mix_bench(warmup, itr, con):
+    query_two_items = "SELECT * FROM lineitem ORDER BY L_LINENUMBER,L_SHIPINSTRUCT"
+    query_three_items = (
+        "SELECT * FROM lineitem ORDER BY L_LINENUMBER,L_SHIPINSTRUCT,L_SHIPMODE"
+    )
+    query_four_items = "SELECT * FROM lineitem ORDER BY L_LINENUMBER,L_SHIPINSTRUCT,L_SHIPMODE,L_DISCOUNT"
+    res_2 = benchmark(
+        "Mix Test With 1 number attribute and 1 string attribute",
+        2,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_two_items,
+        con,
+    )
+    res_3 = benchmark(
+        "Mix Test With 1 number attribute and 2 string attribute",
+        3,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_three_items,
+        con,
+    )
+    res_4 = benchmark(
+        "Mix Test With 2 number attribute and 2 string attribute",
+        4,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_four_items,
+        con,
+    )
+    return [res_2, res_3, res_4]
+
+
+def number_bench(warmup, itr, con):
+    query_one_item_1 = "SELECT * FROM lineitem ORDER BY L_SUPPKEY"
+    query_two_item = "SELECT * FROM lineitem ORDER BY L_LINENUMBER, L_RECEIPTDATE"
+    query_three_item = "SELECT * FROM lineitem ORDER BY L_LINENUMBER, L_DISCOUNT, L_TAX"
+    query_four_item = "SELECT * FROM lineitem ORDER BY L_LINENUMBER, L_DISCOUNT, L_QUANTITY, L_EXTENDEDPRICE"
+    res1 = benchmark(
+        "Number Test With 1 attribute",
+        1,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_one_item_1,
+        con,
+    )
+    res2 = benchmark(
+        "Number Test With 2 attributes",
+        2,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_two_item,
+        con,
+    )
+    res3 = benchmark(
+        "Number Test With 3 attributes",
+        3,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_three_item,
+        con,
+    )
+    res4 = benchmark(
+        "Number Test With 4 attributes",
+        4,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_four_item,
+        con,
+    )
+    return [res1, res2, res3, res4]
+
+
+def string_bench(warmup, itr, con):
+    query_one_item_fixed = "SELECT * FROM lineitem ORDER BY L_SHIPMODE"
+    query_two_item = "SELECT * FROM lineitem ORDER BY L_SHIPMODE, L_SHIPINSTRUCT"
+    query_three_item = (
+        "SELECT * FROM lineitem ORDER BY L_SHIPMODE, L_SHIPINSTRUCT, L_RETURNFLAG"
+    )
+    query_four_item = "SELECT * FROM lineitem ORDER BY L_SHIPMODE, L_SHIPINSTRUCT, L_RETURNFLAG, L_COMMENT"
+    res1 = benchmark(
+        "String Test With 1 attribute",
+        1,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_one_item_fixed,
+        con,
+    )
+    res2 = benchmark(
+        "String Test With 2 attributes",
+        2,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_two_item,
+        con,
+    )
+    res3 = benchmark(
+        "String Test With 3 attributes",
+        3,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_three_item,
+        con,
+    )
+    res4 = benchmark(
+        "String Test With 4 attributes",
+        4,
+        duckdb_sort,
+        warmup,
+        itr,
+        query_four_item,
+        con,
+    )
+    return [res1, res2, res3, res4]
+
+
+# Draw graphs
+def plot_res(res, file_name=None):
+    # Check existence of ratio attribute
+    for r in res:
+        if "Read/Sort Ratio" not in r:
+            print(
+                "The result does not contain the ratio attribute,use add_percentage() first."
+            )
+            return
+    attr_counts = []
+    ratios = []
+    # Clear previous plot
+    plt.clf()
+    for r in res:
+        attr_counts.append(r["Number of Attributes"])
+        ratios.append(r["Read/Sort Ratio"])
+
+    plt.bar(attr_counts, ratios)
+    for i in range(len(attr_counts)):
+        plt.text(
+            attr_counts[i],
+            ratios[i],
+            f"{ratios[i]:.2f}",
+            ha="center",
+            va="bottom",
+            fontsize=7,
+        )
+
+    plt.xlabel("Number of Attributes")
+    plt.ylabel("Read/Sort Ratio")
+    if file_name is not None:
+        plt.savefig(file_name)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    scale = args.scale
+    data_dir = f"{workdir}/data/tpch/s{scale}"
+    # Check the existence of the data directory
+    if not os.path.exists(data_dir):
+        print(
+            f"Data directory {data_dir} does not exist.Use gen_tpc_data.py to generate the data first."
+        )
+        exit(-1)
+    # This table contains most records and attributes
+    file_name = f"{data_dir}/lineitem.parquet"
+    output_file = args.output
+    con = duckdb_preapre(scale, table_src_name="lineitem.parquet")
+    # Increase priority
+    os.nice(-20)
+
+    # Benchmarks
+    read_time = benchmark(
+        "Arrow Read Benchmark", 0, arrow_read, args.warmup, args.iterations, file_name
+    )
+    number_res = number_bench(args.warmup, args.iterations, con)
+    string_res = string_bench(args.warmup, args.iterations, con)
+    mix_res = mix_bench(args.warmup, args.iterations, con)
+    add_percentage(read_time["avg"], number_res)
+    add_percentage(read_time["avg"], string_res)
+    add_percentage(read_time["avg"], mix_res)
+    # Generate plot graph
+    plot_res(number_res, f"number_sort_ratio_{scale}.png")
+    plot_res(string_res, f"string_sort_ratio_{scale}.png")
+    plot_res(mix_res, f"mix_sort_ratio_{scale}.png")
+    # Write the result to a json file
+    with open(output_file, "w") as f:
+        json.dump(
+            {
+                "Read Time": read_time,
+                "Number Sort": number_res,
+                "String Sort": string_res,
+                "Mix Sort": mix_res,
+            },
+            f,
+            indent=4,
+        )
+    con.close()

--- a/build_third_party.sh
+++ b/build_third_party.sh
@@ -23,7 +23,7 @@ FOLLY_SOURCE=folly-v2022.11.14.00
 FOLLY_SHA256="b249436cb61b6dfd5288093565438d8da642b07ae021191a4042b221bc1bdc0e"
 
 # arrow
-ARROW_VERSION=apache-arrow-15.0.0
+ARROW_VERSION=release-15.0.0-rc0
 
 check_if_source_exist() {
   if [ -z $1 ]; then
@@ -79,7 +79,7 @@ build_folly() {
 download_arrow() {
   mkdir -p $third_party_dir
   pushd $third_party_dir
-  if [ -e arrow ]; then git clone https://github.com/apache/arrow.git; fi
+  if [ ! -e arrow ]; then git clone https://github.com/apache/arrow.git; fi
   cd arrow
   git checkout ${ARROW_VERSION}
   popd


### PR DESCRIPTION
# What work have been done in this PR

1. Fixed a bug in `build_third_party.sh` (existence check for the arrow directory).
2. Revised the arrow version name to match the branch name on the arrow official site [confirmation needed].
3. Added a benchmark script `with_duckdb.py` for the read-sorting ratio.
4. Included a benchmark description document and current results.
5. Revised the `.gitignore` to ignore possible outputs generated by the script.

# Code format

Both Black and isort have been used to format the code using their default settings.

# Help wanted

1. Please help to check the logic of the benchmark. Benchmark logic and settings can be found in README.md in correspoonding folder. Should we eliminate the cache effect?
2. I revised the `ARROW_VERSION` defined in the `build_third_party.sh` since it was not matching any branch name in the arrow repository provided in the script. I changed it to `release-15.0.0-rc0` for correct building, but it needs further verification.
